### PR TITLE
Make mkcert work with Firefox

### DIFF
--- a/dev/tasks/mkcert.py
+++ b/dev/tasks/mkcert.py
@@ -23,6 +23,7 @@ class Mkcert(Task):
         if not args:
             return
 
+        HomebrewHelper.install_formula('nss')
         HomebrewHelper.install_formula('mkcert')
         run_command('mkcert -install', silent=True)
 


### PR DESCRIPTION
```
$ mkcert -install
The local CA is already installed in the system trust store! 👍
Warning: "certutil" is not available, so the CA can't be automatically installed in Firefox! ⚠️
Install "certutil" with "brew install nss" and re-run "mkcert -install" 👈
```